### PR TITLE
Fix OpenSSL deprecated warning

### DIFF
--- a/lib/ffxcodec/encrypt.rb
+++ b/lib/ffxcodec/encrypt.rb
@@ -143,7 +143,7 @@ class FFXCodec
     end
 
     def aes(block)
-      aes = OpenSSL::Cipher::Cipher.new('aes-128-ecb')
+      aes = OpenSSL::Cipher.new('aes-128-ecb')
       aes.encrypt
       aes.key = @key
       aes.update(block)


### PR DESCRIPTION
constant `OpenSSL::Cipher::Cipher` has been changed to constant `OpenSSL::Cipher`